### PR TITLE
Update README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ Installation
 ============
 
 1. Download the code with git
-2. Install the required packages: ``pip install -r REQUIREMENTS.txt``
+2. Install the required packages: ``pip install -r requirements.txt``
 
 Features
 ========


### PR DESCRIPTION
The README specified the user should run `pip install -r REQUIREMENTS.txt`
however the requirements file is actually in lowercase, so adjust the README
to match the travis script: `pip install -r requirements.txt`